### PR TITLE
Magic link reusability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 .DS_Store
+build/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,58 @@ Magic Link Auth is a WordPress plugin that enables passwordless login via email 
 - JavaScript events for custom success and error handling.
 - Extensibility through WordPress filters.
 - Handles `HEAD` requests to prevent token invalidation by email link scanners.
+- Configurable token reusability to handle email scanners and security tools that pre-click links.
+- Flexible expiration settings (minutes, hours, or days).
 
 ## Installation
 
 1. Upload the `wp-magic-link-auth` folder to your `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
+
+## Configuration
+
+The plugin provides an admin settings page under **Settings > WP Magic Link Auth** where you can configure various options:
+
+### Email Settings
+
+- **Email Subject:** Customize the subject line of the magic link email.
+- **Email Message:** Customize the email body. You can use the following placeholders:
+  - `{magic_link}` - The magic link URL
+  - `{user_email}` - The user's email address
+  - `{user_login}` - The user's login username
+  - `{display_name}` - The user's display name
+
+### Token Reusability Settings
+
+Configure how magic links can be reused to handle email scanners and other automated tools that may click links before the user:
+
+- **Maximum Usage Count:** Set the maximum number of times a magic link can be used (default: 1). 
+  - Set to `1` for traditional single-use links
+  - Set to higher values (e.g., `3-5`) to handle email scanners that follow links before the user
+  - Maximum allowed: `100`
+
+- **Validity Duration:** Set how long the magic link remains valid before expiring (default: 5 minutes).
+  - Choose the time unit: Minutes, Hours, or Days
+  - After this period, the link expires regardless of usage count
+
+**Configuration Examples:**
+
+- **Single-use, 5 minutes** (default): Usage count = `1`, Duration = `5 minutes` - Traditional behavior, link deleted after first use
+- **Allow 3 uses within 10 minutes**: Usage count = `3`, Duration = `10 minutes` - Ideal for handling email scanners
+- **Unlimited uses for 1 hour**: Usage count = `100`, Duration = `1 hour` - Link can be reused freely within the time window
+- **Single-use, valid for 1 day**: Usage count = `1`, Duration = `1 day` - One-time use but user has 24 hours to click it
+- **5 uses in 30 minutes**: Usage count = `5`, Duration = `30 minutes` - Multiple attempts allowed within time limit
+
+The plugin tracks usage count internally and automatically deletes tokens when they reach the maximum usage count or expire.
+
+### Logging Settings
+
+- **Enable Console Logging for AJAX Calls:** Enable/disable JavaScript console logging for debugging purposes.
+
+### Form Settings
+
+- **Email Label:** Customize the label for the email input field (default: "Email:")
+- **Button Text:** Customize the submit button text (default: "Login")
 
 ## Usage
 
@@ -43,10 +90,14 @@ https://example.com/login-page/?returnUrl=/custom-redirect/
 
 **How it works:**
 
-1. When a user enters its email address in the login form and submits it, the plugin generates a unique, single-use token and sends it to the user's email address in a magic link.
+1. When a user enters its email address in the login form and submits it, the plugin generates a unique token and sends it to the user's email address in a magic link.
 2. When the user clicks the magic link, the plugin verifies the token and automatically logs them in. 
 3. The user is then redirected to the specified `return-url` (or the `returnUrl` query string parameter if provided).
 4. The plugin handles `HEAD` requests (commonly sent by email link scanners) to prevent token invalidation. These requests are ignored, and the token remains valid.
+5. Token reusability is managed according to your configuration settings:
+   - The token expires after the configured validity duration
+   - The token is deleted after reaching the maximum usage count
+   - Each use increments the usage counter
 
 ### Event Message Handling
 
@@ -112,9 +163,13 @@ add_filter('wp_magic_link_auth_pre_login_check', function($user) {
 
 ## Security
 
-- This plugin uses session-based single-use tokens, which are generated randomly and invalidated immediately after a single use.
-- The plugin also implements basic rate limiting to prevent brute-force attacks.
+- This plugin uses session-based tokens, which are generated randomly using cryptographically secure functions.
+- Tokens can be configured for single-use or limited reusability to balance security with usability.
+- Token usage is tracked and enforced, with automatic deletion after reaching the maximum usage count.
+- Time-based expiration ensures tokens cannot be used indefinitely.
+- The plugin implements basic rate limiting to prevent brute-force attacks.
 - `HEAD` requests are handled to prevent email link scanners from invalidating tokens.
+- All tokens are stored securely in the WordPress database with proper sanitization.
 
 ## Contributing
 

--- a/admin/settings-page.php
+++ b/admin/settings-page.php
@@ -15,7 +15,12 @@ if (isset($_POST['wp_magic_link_auth_submit'])) {
     update_option('wp_magic_link_auth_email_message', wp_kses_post($_POST['wp_magic_link_auth_email_message']));
     update_option('wp_magic_link_auth_enable_logging', isset($_POST['wp_magic_link_auth_enable_logging']) ? 'yes' : 'no');
     update_option('wp_magic_link_auth_form_label', sanitize_text_field($_POST['wp_magic_link_auth_form_label']));
-    update_option('wp_magic_link_auth_form_button', sanitize_text_field($_POST['wp_magic_link_auth_form_button'])); 
+    update_option('wp_magic_link_auth_form_button', sanitize_text_field($_POST['wp_magic_link_auth_form_button']));
+    
+    // Token reusability settings
+    update_option('wp_magic_link_auth_max_usage_count', intval($_POST['wp_magic_link_auth_max_usage_count']));
+    update_option('wp_magic_link_auth_validity_duration', intval($_POST['wp_magic_link_auth_validity_duration']));
+    update_option('wp_magic_link_auth_validity_unit', sanitize_text_field($_POST['wp_magic_link_auth_validity_unit'])); 
 }
 
 // Get current settings
@@ -27,6 +32,11 @@ $emailMessage = get_option(
 $enableLogging = get_option('wp_magic_link_auth_enable_logging', 'yes');
 $formLabel = get_option('wp_magic_link_auth_form_label', 'Email:');
 $formButton = get_option('wp_magic_link_auth_form_button', 'Login');
+
+// Token reusability settings
+$maxUsageCount = get_option('wp_magic_link_auth_max_usage_count', 1);
+$validityDuration = get_option('wp_magic_link_auth_validity_duration', 5);
+$validityUnit = get_option('wp_magic_link_auth_validity_unit', 'minutes');
 
 ?>
 <div class="wrap">
@@ -83,6 +93,43 @@ $formButton = get_option('wp_magic_link_auth_form_button', 'Login');
                 </tr>
             </tbody>
         </table>
+        <h2>Token Reusability Settings</h2>
+        <table class="form-table">
+            <tbody>
+                <tr>
+                    <th scope="row"><label for="wp_magic_link_auth_max_usage_count">Maximum Usage Count:</label></th>
+                    <td>
+                        <input type="number" name="wp_magic_link_auth_max_usage_count" id="wp_magic_link_auth_max_usage_count" value="<?php echo esc_attr($maxUsageCount); ?>" min="1" max="100" class="small-text">
+                        <p class="description">
+                            Maximum number of times a magic link can be used. Set to 1 for single-use links (default). 
+                            Higher values help with email scanners that click links before the user.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="wp_magic_link_auth_validity_duration">Validity Duration:</label></th>
+                    <td>
+                        <input type="number" name="wp_magic_link_auth_validity_duration" id="wp_magic_link_auth_validity_duration" value="<?php echo esc_attr($validityDuration); ?>" min="1" class="small-text">
+                        <select name="wp_magic_link_auth_validity_unit" id="wp_magic_link_auth_validity_unit">
+                            <option value="minutes" <?php selected($validityUnit, 'minutes'); ?>>Minutes</option>
+                            <option value="hours" <?php selected($validityUnit, 'hours'); ?>>Hours</option>
+                            <option value="days" <?php selected($validityUnit, 'days'); ?>>Days</option>
+                        </select>
+                        <p class="description">
+                            How long the magic link remains valid. After this period, the link expires regardless of usage count.
+                            Default is 5 minutes.
+                        </p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <p class="description">
+            <strong>Examples:</strong><br>
+            • Single-use, 5 minutes: Set usage count to 1 and duration to 5 minutes (default behavior)<br>
+            • Allow 3 uses within 10 minutes: Set usage count to 3 and duration to 10 minutes<br>
+            • Unlimited uses for 1 hour: Set usage count to 100 and duration to 1 hour<br>
+            • Single-use, valid for 1 day: Set usage count to 1 and duration to 1 day
+        </p>
         <?php submit_button('Save Settings', 'primary', 'wp_magic_link_auth_submit'); ?>
     </form>
 </div>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Build script for WP Magic Link Auth plugin
+# Version 1.0
+# Date: October 23, 2025
+
+# Terminal colors
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
+# Get the script directory path
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PLUGIN_DIR="$SCRIPT_DIR"
+BUILD_DIR="$PLUGIN_DIR/build"
+TEMP_DIR="$BUILD_DIR/wp-magic-link-auth"
+PLUGIN_NAME="wp-magic-link-auth"
+VERSION=$(grep "Version:" "$PLUGIN_DIR/wp-magic-link-auth.php" | awk -F': ' '{print $2}' | tr -d '\r')
+
+echo -e "${YELLOW}========================================${NC}"
+echo -e "${YELLOW}  WP Magic Link Auth Plugin Packager   ${NC}"
+echo -e "${YELLOW}========================================${NC}"
+echo -e "${GREEN}Plugin Version:${NC} $VERSION"
+echo -e "${GREEN}Plugin Directory:${NC} $PLUGIN_DIR"
+
+# Cleanup function
+cleanup() {
+    echo -e "\n${YELLOW}Cleaning temporary directories...${NC}"
+    rm -rf "$BUILD_DIR"
+    echo -e "${GREEN}Done!${NC}"
+}
+
+# Error handling
+handle_error() {
+    echo -e "\n${RED}Error during packaging. Operation aborted.${NC}"
+    cleanup
+    exit 1
+}
+
+# Trap to catch errors
+trap 'handle_error' ERR
+
+# Create build directory
+echo -e "\n${YELLOW}Creating build directory...${NC}"
+mkdir -p "$TEMP_DIR"
+
+# Skip Gutenberg blocks compilation (not applicable for this plugin)
+# echo -e "\n${YELLOW}Compiling Gutenberg blocks...${NC}"
+# cd "$PLUGIN_DIR/blocks/gutenberg"
+# npx webpack --mode=production
+# echo -e "${GREEN}Compilation completed.${NC}"
+
+# List of files and directories to include
+echo -e "\n${YELLOW}Copying essential files...${NC}"
+INCLUDE_DIRS=(
+    "admin"
+    "assets"
+    "includes"
+)
+
+INCLUDE_FILES=(
+    "wp-magic-link-auth.php"
+    "LICENSE"
+    "README.md"
+)
+
+# Copy directories to temporary directory
+for dir in "${INCLUDE_DIRS[@]}"; do
+    mkdir -p "$TEMP_DIR/$(dirname "$dir")"
+    cp -R "$PLUGIN_DIR/$dir" "$TEMP_DIR/$(dirname "$dir")/"
+    echo -e "${GREEN}Copied directory:${NC} $dir"
+done
+
+# Copy individual files
+for file in "${INCLUDE_FILES[@]}"; do
+    cp "$PLUGIN_DIR/$file" "$TEMP_DIR/$file"
+    echo -e "${GREEN}Copied file:${NC} $file"
+done
+
+# Remove unnecessary files
+echo -e "\n${YELLOW}Removing unnecessary files...${NC}"
+find "$TEMP_DIR" -name ".DS_Store" -delete
+find "$TEMP_DIR" -name "*.map" -delete
+find "$TEMP_DIR" -name "node_modules" -type d -exec rm -rf {} +
+
+# Create final ZIP file
+echo -e "\n${YELLOW}Creating ZIP file...${NC}"
+cd "$BUILD_DIR"
+zip -r "${PLUGIN_NAME}-${VERSION}.zip" "$PLUGIN_NAME"
+echo -e "${GREEN}ZIP file created:${NC} ${PLUGIN_NAME}-${VERSION}.zip"
+
+# Final information
+echo -e "\n${YELLOW}========================================${NC}"
+echo -e "${GREEN}Package created successfully!${NC}"
+echo -e "${GREEN}Path:${NC} $BUILD_DIR/${PLUGIN_NAME}-${VERSION}.zip"
+
+# Clean temporary directories but keep the ZIP file
+echo -e "\n${YELLOW}Cleaning temporary directories...${NC}"
+rm -rf "$TEMP_DIR"
+echo -e "${GREEN}Done!${NC}"
+
+exit 0

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -18,12 +18,41 @@ function create_auth_requests_table() {
         user_id bigint(20) NOT NULL,
         token varchar(100) NOT NULL,
         created_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
+        usage_count int(11) DEFAULT 0 NOT NULL,
         PRIMARY KEY (id),
         UNIQUE KEY token (token)
     ) $charset_collate;";
 
     require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
     dbDelta($sql);
+}
+
+// Function to migrate existing tables by adding the usage_count column
+function magic_link_auth_maybe_upgrade_db() {
+    global $wpdb;
+    
+    // Check if the table exists
+    $table_name = MAGIC_LINK_AUTH_REQUESTS_TABLE;
+    if($wpdb->get_var("SHOW TABLES LIKE '$table_name'") != $table_name) {
+        return; // Table doesn't exist, no migration needed
+    }
+    
+    // Check if usage_count column exists
+    $column_exists = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT * FROM INFORMATION_SCHEMA.COLUMNS 
+            WHERE TABLE_SCHEMA = %s 
+            AND TABLE_NAME = %s 
+            AND COLUMN_NAME = 'usage_count'",
+            DB_NAME,
+            $table_name
+        )
+    );
+    
+    // Add the column if it doesn't exist
+    if(empty($column_exists)) {
+        $wpdb->query("ALTER TABLE $table_name ADD COLUMN usage_count int(11) DEFAULT 0 NOT NULL AFTER created_at");
+    }
 }
 
 function drop_auth_requests_table() {
@@ -33,6 +62,7 @@ function drop_auth_requests_table() {
 
 function magic_link_auth_activate() {
     create_auth_requests_table();
+    magic_link_auth_maybe_upgrade_db();
 }
 
 function magic_link_auth_deactivate() {

--- a/wp-magic-link-auth.php
+++ b/wp-magic-link-auth.php
@@ -168,6 +168,55 @@ function magic_link_auth_redirect($base_url, $params = []) {
     exit;
 }
 
+// Get token expiration time based on configuration
+function magic_link_auth_get_token_expiration($created_at) {
+    $validity_duration = intval(get_option('wp_magic_link_auth_validity_duration', 5));
+    $validity_unit = get_option('wp_magic_link_auth_validity_unit', 'minutes');
+    
+    $multiplier = 60; // Default to minutes
+    if ($validity_unit === 'hours') {
+        $multiplier = 60 * 60;
+    } else if ($validity_unit === 'days') {
+        $multiplier = 60 * 60 * 24;
+    }
+    
+    return strtotime($created_at) + ($validity_duration * $multiplier);
+}
+
+// Check if token has expired
+function magic_link_auth_is_token_expired($request) {
+    $expiration = magic_link_auth_get_token_expiration($request->created_at);
+    return time() > $expiration;
+}
+
+// Handle token usage: update count or delete based on configuration
+function magic_link_auth_handle_token_usage($request) {
+    global $wpdb;
+    
+    $max_usage_count = intval(get_option('wp_magic_link_auth_max_usage_count', 1));
+    $current_usage = intval($request->usage_count) + 1;
+    
+    if ($current_usage >= $max_usage_count) {
+        // Max usage reached, delete the token
+        $wpdb->delete(
+            MAGIC_LINK_AUTH_REQUESTS_TABLE,
+            ['id' => $request->id],
+            ['%d']
+        );
+        return true; // Token deleted
+    } else {
+        // Update usage count
+        $wpdb->update(
+            MAGIC_LINK_AUTH_REQUESTS_TABLE,
+            ['usage_count' => $current_usage],
+            ['id' => $request->id],
+            ['%d'],
+            ['%d']
+        );
+        return false; // Token still valid
+    }
+}
+
 // Handle the authentication process.
 function authenticate_passwordless_login() {
     if (isset($_GET['token'])) {
@@ -193,20 +242,21 @@ function authenticate_passwordless_login() {
             if ($request) {
                 $user = get_user_by('id', $request->user_id);
 
-                // Check if the token is expired (5 minutes from created_at)
-                $expiration = strtotime($request->created_at) + (5 * 60);
-                if (time() > $expiration) {
+                // Check if the token is expired
+                if (magic_link_auth_is_token_expired($request)) {
+                    // Delete the expired token
+                    $wpdb->delete(
+                        MAGIC_LINK_AUTH_REQUESTS_TABLE,
+                        ['id' => $request->id],
+                        ['%d']
+                    );
                     magic_link_auth_redirect(home_url('/login/'), [
                         'token_expired' => 1
                     ]);
                 }
 
-                // Delete the token to prevent reuse
-                $wpdb->delete(
-                    MAGIC_LINK_AUTH_REQUESTS_TABLE,
-                    ['id' => $request->id],
-                    ['%d']
-                );
+                // Handle token usage: increment count or delete if max reached
+                magic_link_auth_handle_token_usage($request);
 
                 // Allow other plugins to perform additional checks before logging in the user.
                 $check_result = apply_filters('wp_magic_link_auth_pre_login_check', $user);

--- a/wp-magic-link-auth.php
+++ b/wp-magic-link-auth.php
@@ -157,6 +157,17 @@ function send_magic_link() {
 add_action('wp_ajax_send_magic_link', 'send_magic_link');
 add_action('wp_ajax_nopriv_send_magic_link', 'send_magic_link');
 
+// Helper function for consistent redirects
+function magic_link_auth_redirect($base_url, $params = []) {
+    if (!empty($params)) {
+        $url = add_query_arg($params, $base_url);
+    } else {
+        $url = $base_url;
+    }
+    wp_redirect($url);
+    exit;
+}
+
 // Handle the authentication process.
 function authenticate_passwordless_login() {
     if (isset($_GET['token'])) {
@@ -185,8 +196,9 @@ function authenticate_passwordless_login() {
                 // Check if the token is expired (5 minutes from created_at)
                 $expiration = strtotime($request->created_at) + (5 * 60);
                 if (time() > $expiration) {
-                    wp_redirect($returnUrl . '?token_expired=1'); // Redirect with error
-                    exit;
+                    magic_link_auth_redirect(home_url('/login/'), [
+                        'token_expired' => 1
+                    ]);
                 }
 
                 // Delete the token to prevent reuse
@@ -201,8 +213,9 @@ function authenticate_passwordless_login() {
 
                 // Handle WP_Error in the response
                 if (is_wp_error($check_result)) {
-                    wp_redirect($returnUrl . '?login_error=' . urlencode($check_result->get_error_message()));
-                    exit;
+                    magic_link_auth_redirect(home_url('/login/'), [
+                        'login_error' => $check_result->get_error_message()
+                    ]);
                 }
 
                 // Handle array response with a 'state' key
@@ -210,8 +223,9 @@ function authenticate_passwordless_login() {
                     if (isset($check_result['state']) && !$check_result['state']) {
                         // Redirect with error message if the check fails.
                         $error_message = isset($check_result['message']) ? $check_result['message'] : 'An unknown error occurred.';
-                        wp_redirect($returnUrl . '?login_error=' . urlencode($error_message));
-                        exit;
+                        magic_link_auth_redirect(home_url('/login/'), [
+                            'login_error' => $error_message
+                        ]);
                     }
                 }
 
@@ -222,18 +236,19 @@ function authenticate_passwordless_login() {
 
                 // Handle any other unexpected response types
                 if ($check_result !== true) {
-                    wp_redirect($returnUrl . '?login_error=' . urlencode('An unexpected error occurred.'));
-                    exit;
+                    magic_link_auth_redirect(home_url('/login/'), [
+                        'login_error' => 'An unexpected error occurred.'
+                    ]);
                 }
 
                 // Log the user in.
                 wp_set_auth_cookie($user->ID, true);
-                wp_redirect($returnUrl); // Redirect to the intended page after login.
-                exit;
+                magic_link_auth_redirect($returnUrl); // Redirect to the intended page after login.
             } else {
                 // Token not found or invalid
-                wp_redirect($returnUrl . '?token_invalid=1'); // Redirect with error
-                exit;
+                magic_link_auth_redirect(home_url('/login/'), [
+                    'token_invalid' => 1
+                ]);
             }
         }
     }


### PR DESCRIPTION
This pull request introduces configurable token reusability and flexible expiration settings to the WP Magic Link Auth plugin, allowing administrators to control how many times a magic link can be used and for how long it remains valid. It also updates the database schema, plugin logic, and admin UI to support these features, and improves documentation and packaging.

**Token Reusability and Expiration Features**

* Added admin settings for maximum usage count and validity duration/unit for magic links, enabling single-use or limited multi-use tokens
* Updated documentation to explain new configuration options, usage scenarios, and security implications

**Database Changes**

* Modified the `auth_requests` table to include a `usage_count` column for tracking token usage.
* Added a migration function to upgrade existing tables by adding the `usage_count` column if missing.

**Authentication Logic Improvements**

* Implemented logic to check token expiration based on configurable duration/unit, and to increment/delete tokens based on usage count
* Refactored redirects to use a helper function for consistency and to handle error states more cleanly

**Packaging and Build**

* Added a new `build.sh` script for packaging the plugin, including directory cleanup and ZIP creation.

**Security and Documentation Updates**

* Enhanced documentation to clarify token lifecycle, security practices, and database storage, reflecting new features.